### PR TITLE
property useUuidForIdentifierManifest in options object, to disable auto generate unique identifier in manifest

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,8 @@
 # scopackager changelog
 
+## 0.2.6
+* setting `useUuidForIdentifierManifest: false` in the options object, the `identifier` will be used for the manifest identifier.
+
 ## 0.2.5
 * changed behavior of adding timestamp to .zip file: by default, this is *not* added. It can be added by setting `package.appendTimeToOutput: true` in the options object.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-`version 0.2.5`
+`version 0.2.6`
 
 ## Documentation
 
@@ -25,6 +25,8 @@ npm install simple-scorm-packager
 * `organization` {string} [''] Company name
 * `language` {string} ['en'] Language of the package ( ISO )
 * `title` {string} ['']
+* `useUuidForIdentifierManifest` {boolean} [true] If true, property identifier in config is ignored for the manifest identifier, it will be calculated using:
+  \`${package.author || 'com'}.${organization || 'company'}.${title || ''}.${generated uuid}\`  
 * `identifier` {string} [null] If empty, identifier is generated using:
 \`${package.author || 'com'}.${organization || 'company'}.${title || ''}.${generated uuid}\`
 * `masteryScore` {number} [80]

--- a/cli.js
+++ b/cli.js
@@ -34,6 +34,7 @@ var settings = {
   language: "en",
   organization: "",
   title: getPackageName(),
+  useUuidForIdentifierManifest: true,
   identifier: "",
   masteryScore: 80,
   startingPage: "index.html",

--- a/lib/schemas/config.js
+++ b/lib/schemas/config.js
@@ -43,6 +43,7 @@ module.exports = function(obj) {
         language: obj.language || 'en',
         organization: obj.organization || '',
         title: obj.title || '',
+        useUuidForIdentifierManifest: obj.useUuidForIdentifierManifest !== false ? true : false,
         identifier: obj.identifier,
         masteryScore: obj.masteryScore != null ? obj.masteryScore : 80,
         startingPage: obj.startingPage || 'index.html',

--- a/lib/schemas/scorm12.js
+++ b/lib/schemas/scorm12.js
@@ -7,6 +7,7 @@ module.exports = function(obj) {
   if (obj.identifier) {
     if (obj.identifier.trim()) {
       var ri = obj.identifier.replace(/ /g, "");
+      identifier = obj.useUuidForIdentifierManifest ? identifier : ri;
       itemIdentifier = "item_" + ri;
       identifierref = "resource_" + ri;
     }

--- a/lib/schemas/scorm2004.js
+++ b/lib/schemas/scorm2004.js
@@ -7,6 +7,7 @@ module.exports = function(obj) {
   if (obj.identifier) {
     if (obj.identifier.trim()) {
       var ri = obj.identifier.replace(/ /g, "");
+      identifier = obj.useUuidForIdentifierManifest ? identifier : ri;
       itemIdentifier = "item_" + ri;
       identifierref = "resource_" + ri;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-scorm-packager",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Simple way to package your scorm projects",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
Hi!
Setting identifier in options object it is used only for resources and items, but at manifest level it is always generated on demand.
This behavior can be useful when creating new scorm that requires unique new identifier, but sometimes I need to update an existing scorm, maintaining the same specified identifier.

To disable the default behavior (manifest identifier with uuid) I added a useUuidForIdentifierManifest property in options object, that is true by default, leaving it generated with uuid by default.
That way, when set to false, identifier value is used in resources, items and manifest tag also.

You can merge it if you think this feature can be useful to someone else.